### PR TITLE
Move sphinx build to execution phase

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,17 +11,66 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 load("@score_docs_as_code//:docs.bzl", "docs")
 
 docs(
     data = [
-        "@score_platform//:needs_json",
-        "@score_process//:needs_json",
+        # "@score_platform//:",
+        "@score_process//:sphinx_docs_library",
+        "@score_baselibs//:sphinx_docs_library",
         # Persistency cannot be included, as it does not contain any needs.
         # -> sphinx-needs bug?
         # "@score_persistency//:needs_json",
     ],
     source_dir = "docs",
+    deps = [
+    ],
+)
+
+source_dir = "docs"
+
+sphinx_docs(
+    name = "html",
+    srcs = glob(
+        [
+            source_dir + "/**/*.png",
+            source_dir + "/**/*.svg",
+            source_dir + "/**/*.md",
+            source_dir + "/**/*.rst",
+            source_dir + "/**/*.html",
+            source_dir + "/**/*.css",
+            source_dir + "/**/*.puml",
+            source_dir + "/**/*.need",
+            source_dir + "/**/*.yaml",
+            source_dir + "/**/*.json",
+            source_dir + "/**/*.csv",
+            source_dir + "/**/*.inc",
+            "more_docs/**/*.rst",
+        ],
+        allow_empty = True,
+    ),
+    config = ":" + source_dir + "/conf.py",
+    extra_opts = [
+        "-W",
+        "--keep-going",
+        "-T",  # show more details in case of errors
+        "--jobs",
+        "auto",
+    ],
+    formats = ["html"],
+    sphinx = ":sphinx_build",
+    tools = [],
+    visibility = ["//visibility:public"],
+    # Modules export their docs as sphinx_docs_library
+    # which are imported by bazel to docs/modules/<module_name>
+    deps = [
+        "@score_platform//:sphinx_docs_library",
+        "@score_process//:sphinx_docs_library",
+        "@score_baselibs//:sphinx_docs_library",
+        # "@score_persistency//:sphinx_docs_library",
+        # "@score_communication//:sphinx_docs_library"
+    ],
 )
 
 # Simple filegroup target to demonstrate the build system works

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,9 +60,10 @@ git_override(
     module_name = "trlc",
     remote = "https://github.com/bmw-software-engineering/trlc.git",
     commit = "650b51a47264a4f232b3341f473527710fc32669",  # trlc-2.0.2 release
+    # commit = "650b51a47264a4f232b3341f473527710fc32669",  # trlc-2.0.2 release
 )
 
 # imports for the feature showcase module
-bazel_dep(name = "rules_rust", version = "0.61.0")
+bazel_dep(name = "rules_rust", version = "0.67.0")
 bazel_dep(name = "score_itf", version = "0.1.0")
 bazel_dep(name = "score_crates", version = "0.0.4")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,14 +17,25 @@ Reference Integration Documentation
 
 Release Notes: :need:`doc__score_v05_alpha_release_note`
 
+Documentation:
+-------------- 
 
-.. if-collection:: score_platform
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
 
-   Documentation:
+   modules/score_process+/process/index
+   modules/score_platform+/docs/index
 
-   .. toctree::
-      :maxdepth: 1
-      :titlesonly:
 
-      S-CORE Platform <_collections/score_platform/docs/index>
-      _collections/score_process/process/index
+Modules
+-------
+
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   modules/score_baselibs+/docs/index
+..
+      modules/score_persistency+/docs/index

--- a/score_modules.MODULE.bazel
+++ b/score_modules.MODULE.bazel
@@ -12,9 +12,10 @@
 # *******************************************************************************
 
 bazel_dep(name = "score_baselibs")
-single_version_override(
+git_override(
     module_name = "score_baselibs",
-    version = "0.1.3",
+    commit = "826955b4d7dc2f326e3deabc06895318922cca1f",
+    remote = "https://github.com/eclipse-score/baselibs.git",
 )
 
 bazel_dep(name = "score_communication")
@@ -60,9 +61,15 @@ single_version_override(
 )
 
 bazel_dep(name = "score_docs_as_code", version = "2.0.1")
-single_version_override(
+# single_version_override(
+#     module_name = "score_docs_as_code",
+#     version = "2.0.1",
+# )
+
+git_override(
     module_name = "score_docs_as_code",
-    version = "2.0.1",
+    commit = "c27915a2c5222a2e7111ba8db0cd468110b70178",
+    remote = "https://github.com/eclipse-score/docs-as-code.git",
 )
 
 


### PR DESCRIPTION
This PR shows how a sphinx build can be moved to
the execution phase of bazel builds.

Addditionally, module documentation is now
imported from  `sphinx_docs_library` targets of
dependent modules.

This pr depends on changes in
[PR](https://github.com/eclipse-score/docs-as-code/pull/327)