### PR TITLE
Integrates datarouter in qemu reference_integration platform

### DIFF
--- a/qnx_qemu/.bazelrc
+++ b/qnx_qemu/.bazelrc
@@ -1,11 +1,18 @@
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
 common --registry=https://bcr.bazel.build
 
-build:_common --@score_baselibs//score/mw/log/detail/flags:KUse_Stub_Implementation_Only=False
-build:_common --@score_baselibs//score/mw/log/flags:KRemote_Logging=False
 build:_common --@score_baselibs//score/json:base_library=nlohmann
 build:_common --@score_baselibs//score/memory/shared/flags:use_typedshmd=False
 build:_common --@score_communication//score/mw/com/flags:tracing_library=stub
+
+# Flags needed by datarouter
+build:_common --@score_logging//score/datarouter/build_configuration_flags:persistent_logging=False
+build:_common --@score_logging//score/datarouter/build_configuration_flags:persistent_config_feature_enabled=False
+build:_common --@score_logging//score/datarouter/build_configuration_flags:enable_nonverbose_dlt=False
+build:_common --@score_logging//score/datarouter/build_configuration_flags:enable_dynamic_configuration_in_datarouter=False
+build:_common --@score_logging//score/datarouter/build_configuration_flags:dlt_file_transfer_feature=False
+build:_common --@score_logging//score/datarouter/build_configuration_flags:use_local_vlan=True
+
 build:_common --cxxopt=-Wno-error=mismatched-new-delete
 
 build:x86_64-qnx --config=_common

--- a/qnx_qemu/build/BUILD
+++ b/qnx_qemu/build/BUILD
@@ -51,11 +51,14 @@ qnx_ifs(
         ":configs",
         "@score_scrample//src:scrample",
         "//scrample_integration:etc_configs",
-        "@score_persistency//tests/cpp_test_scenarios:cpp_test_scenarios",        
+        "//datarouter_integration:etc_configs",
+        "@score_persistency//tests/cpp_test_scenarios:cpp_test_scenarios",
+        "@score_logging//score/datarouter:datarouter",
     ],
     ext_repo_maping = {
         "SCRAMPLE_PATH": "$(location @score_scrample//src:scrample)",
         "CPP_TEST_SCENARIOS_PATH": "$(location @score_persistency//tests/cpp_test_scenarios:cpp_test_scenarios)",
+        "DATAROUTER_PATH": "$(location @score_logging//score/datarouter:datarouter)",
     },
     visibility = [
         "//:__pkg__"

--- a/qnx_qemu/build/system.build
+++ b/qnx_qemu/build/system.build
@@ -66,7 +66,7 @@ libpam.so.2                              # Pluggable Authentication Modules libr
 # Note: /bin/sh symlink already defined in init.build as /proc/boot/ksh
 toybox                                   # Minimal Unix utilities collection (replaces many GNU tools)
 [type=link] cp=toybox                    # Copy files and directories
-[type=link] ls=toybox                    # List directory contents  
+[type=link] ls=toybox                    # List directory contents
 [type=link] cat=toybox                   # Display file contents
 [type=link] chmod=toybox                 # Change file permissions
 [type=link] rm=toybox                    # Remove files and directories
@@ -255,7 +255,7 @@ pci/pci_debug2.so                        # Enhanced PCI debugging support
 [perms=0444] pci_hw.cfg = configs/pci_hw.cfg              # PCI hardware configuration
 [perms=0444] qcrypto.conf = configs/qcrypto.conf          # QNX cryptographic library configuration
 
-# System hostname configuration  
+# System hostname configuration
 /etc/hostname = configs/hostname         # System hostname definition file
 /etc/profile = configs/profile
 
@@ -281,3 +281,13 @@ pci/pci_debug2.so                        # Enhanced PCI debugging support
 
 [perms=777] /scrample = ${SCRAMPLE_PATH}
 [perms=777] /cpp_tests_persistency = ${CPP_TEST_SCENARIOS_PATH}
+
+
+#############################################
+### Datarouter ###
+#############################################
+[perms=777] /usr/bin/datarouter = ${DATAROUTER_PATH}
+
+# Datarouter configuration files (relative to binary: ./etc/)
+[perms=644] /usr/bin/etc/logging.json = datarouter_integration/etc/logging.json
+[perms=644] /usr/bin/etc/log-channels.json = datarouter_integration/etc/log-channels.json

--- a/qnx_qemu/configs/startup.sh
+++ b/qnx_qemu/configs/startup.sh
@@ -82,3 +82,11 @@ mkdir -p /tmp_ram/tmp_discovery
 ln -sP  /tmp_ram/tmp_discovery /tmp_discovery
 
 /proc/boot/sshd -f /var/ssh/sshd_config # Start SSH daemon with specified configuration file
+
+echo "---> Starting datarouter"
+cd /usr/bin
+sleep 2                                 # Brief delay to allow system services to be setup (needed for QNX QEMU timing)
+# start datarouter as nonroot user with pathspace ability
+# pathspace ability provides the datarouter access to the `procnto`
+# pathname prefix space required for mw/com message passing with mw::log frontend
+on -A nonroot,allow,pathspace -u 1051:1091 ./datarouter --no_adaptive_runtime &

--- a/qnx_qemu/datarouter_integration/BUILD
+++ b/qnx_qemu/datarouter_integration/BUILD
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+exports_files([
+    "etc/logging.json",
+    "etc/log-channels.json",
+])
+
+filegroup(
+    name = "etc_configs",
+    srcs = [
+        "etc/logging.json",
+        "etc/log-channels.json",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/qnx_qemu/datarouter_integration/etc/log-channels.json
+++ b/qnx_qemu/datarouter_integration/etc/log-channels.json
@@ -1,0 +1,71 @@
+{
+    "channels": {
+        "3491": {
+            "address": "0.0.0.0",
+            "channelThreshold": "kError",
+            "dstAddress": "239.255.42.99",
+            "dstPort": 3490,
+            "ecu": "SCPP",
+            "port": 3491
+        },
+        "3492": {
+            "address": "0.0.0.0",
+            "channelThreshold": "kInfo",
+            "dstAddress": "239.255.42.99",
+            "dstPort": 3490,
+            "ecu": "SCPP",
+            "port": 3492
+        },
+        "3493": {
+            "address": "0.0.0.0",
+            "channelThreshold": "kVerbose",
+            "dstAddress": "239.255.42.99",
+            "dstPort": 3490,
+            "ecu": "SCPP",
+            "port": 3493
+        }
+    },
+    "channelAssignments": {
+        "DR": {
+            "": [
+                "3492"
+            ],
+            "CTX1": [
+                "3492",
+                "3493"
+            ],
+            "STAT": [
+                "3492"
+            ]
+        },
+        "IPBR": {
+            "": [
+                "3492",
+                "3493"
+            ]
+        },
+        "-NI-": {
+            "": [
+                "3491"
+            ]
+        }
+    },
+    "defaultChannel": "3493",
+    "defaultThresold": "kVerbose",
+    "messageThresholds": {
+        "": {
+            "vcip": "kInfo"
+        },
+        "DR": {
+            "": "kVerbose",
+            "CTX1": "kVerbose",
+            "STAT": "kDebug"
+        },
+        "IPBR": {
+            "": "kVerbose"
+        },
+        "-NI-": {
+            "": "kVerbose"
+        }
+    }
+}

--- a/qnx_qemu/datarouter_integration/etc/logging.json
+++ b/qnx_qemu/datarouter_integration/etc/logging.json
@@ -1,0 +1,9 @@
+{
+  "appId": "DR",
+  "appDesc": "Data Router",
+  "logLevel": "kInfo",
+  "ringBufferSize": 786432,
+  "numberOfSlots": 4,
+  "slotSizeBytes": 4096,
+  "datarouterUid": 1051
+}


### PR DESCRIPTION
Integrates datarouter in qemu reference_integration platform

- Prepares datarouter configurations for deployment
- Deploy datarouter binary
- The startup script - Starts datarouter

