### PR TITLE
codeql: removing the coding-standard repo

### DIFF
--- a/.github/workflows/codeql-multiple-repo-scan.yml
+++ b/.github/workflows/codeql-multiple-repo-scan.yml
@@ -10,9 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-
 name: "CodeQL - Multi-Repo Source Scan"
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -24,10 +22,8 @@ on:
   release:
     types: [created]
   workflow_dispatch:
-
 permissions:
   contents: write
-
 jobs:
   analyze-repos:
     name: Analyze Multiple Repositories
@@ -37,176 +33,164 @@ jobs:
       packages: read
       actions: read
       contents: read
-
     steps:
-    - name: Checkout central repository
-      uses: actions/checkout@v4
+      - name: Checkout central repository
+        uses: actions/checkout@v4
+      - name: Checkout CodeQL Coding Standards scripts
+        uses: actions/checkout@v4
+        with:
+          repository: github/codeql-coding-standards
+          path: codeql-coding-standards-repo # Klonen in diesen Ordner
+          ref: main # Oder eine spezifische Release-Version, z.B. 'v2.53.0-dev'
+      # Add coding standard packages and dependencies
+      - name: Install Python dependencies for Coding Standards scripts
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install pyyaml jsonpath-ng jsonschema jsonpatch jsonpointer pytest sarif-tools
+      - name: Parse known_good.json and create repos.json
+        id: parse-repos
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+          JSON_FILE="./known_good.json"
 
-    - name: Checkout CodeQL Coding Standards scripts
-      uses: actions/checkout@v4
-      with:
-        repository: github/codeql-coding-standards
-        path: codeql-coding-standards-repo # Klonen in diesen Ordner
-        ref: main # Oder eine spezifische Release-Version, z.B. 'v2.53.0-dev'
-
-    # Add coding standard packages and dependencies
-    - name: Install Python dependencies for Coding Standards scripts
-      run: |
-        python3 -m pip install --upgrade pip
-        pip3 install pyyaml jsonpath-ng jsonschema jsonpatch jsonpointer pytest sarif-tools
-
-    - name: Parse known_good.json and create repos.json
-      id: parse-repos
-      run: |
-        sudo apt-get update && sudo apt-get install -y jq
-        JSON_FILE="./known_good.json"
-
-        # Check if the file exists
-        if [ ! -f "$JSON_FILE" ]; then
-          echo "Error file not found '$JSON_FILE' "
-          ls -la .
-          exit 1
-        fi
-
-        # Create repos.json from known_good.json
-        # This jq command transforms the 'modules' object into an array of repository objects
-        # with 'name', 'url', 'version' (branch/tag/hash), and 'path'.
-        jq '[.modules.target_sw | to_entries[] | {
-          name: .key,
-          url: .value.repo,
-          version: (.value.branch // .value.hash // .value.version),
-          path: ("repos/" + .key)
-        }]' "$JSON_FILE" > repos.json
-
-        echo "Generated repos.json:"
-        cat repos.json
-        echo "" # Add a newline for better readability
-
-        # The following GITHUB_OUTPUT variables are set for each module.
-        # These might be useful for other steps, but are not directly used by the 'checkout-repos' step
-        # which now reads 'repos.json' directly.
-        echo "MODULE_COUNT=$(jq '.modules.target_sw | length' "$JSON_FILE")" >> $GITHUB_OUTPUT
-
-        jq -c '.modules.target_sw | to_entries[]' "$JSON_FILE" | while read -r module_entry; do
-          module_name=$(echo "$module_entry" | jq -r '.key')
-          repo_url=$(echo "$module_entry" | jq -r '.value.repo // empty')
-          version=$(echo "$module_entry" | jq -r '.value.version // empty')
-          branch=$(echo "$module_entry" | jq -r '.value.branch // empty')
-          hash=$(echo "$module_entry" | jq -r '.value.hash // empty')
-
-          echo "${module_name}_url=$repo_url" >> $GITHUB_OUTPUT
-
-          if [ -n "$version" ]; then
-           echo "${module_name}_version=$version" >> $GITHUB_OUTPUT
+          # Check if the file exists
+          if [ ! -f "$JSON_FILE" ]; then
+            echo "Error file not found '$JSON_FILE' "
+            ls -la .
+            exit 1
           fi
 
-          if [ -n "$branch" ]; then
-            echo "${module_name}_branch=$branch" >> $GITHUB_OUTPUT
-          fi
+          # Create repos.json from known_good.json
+          # This jq command transforms the 'modules' object into an array of repository objects
+          # with 'name', 'url', 'version' (branch/tag/hash), and 'path'.
+          jq '[.modules.target_sw | to_entries[] | {
+            name: .key,
+            url: .value.repo,
+            version: (.value.branch // .value.hash // .value.version),
+            path: ("repos/" + .key)
+          }]' "$JSON_FILE" > repos.json
 
-          if [ -n "$hash" ]; then
-            echo "${module_name}_hash=$hash" >> $GITHUB_OUTPUT
-          fi
-        done
+          echo "Generated repos.json:"
+          cat repos.json
+          echo "" # Add a newline for better readability
 
-    - name: Checkout all pinned repositories
-      id: checkout-repos
-      run: |
-        # jq is already installed by the previous step.
+          # The following GITHUB_OUTPUT variables are set for each module.
+          # These might be useful for other steps, but are not directly used by the 'checkout-repos' step
+          # which now reads 'repos.json' directly.
+          echo "MODULE_COUNT=$(jq '.modules.target_sw | length' "$JSON_FILE")" >> $GITHUB_OUTPUT
 
-        # Read repositories from the repos.json file created by the previous step
-        repos=$(cat repos.json)
-        repo_count=$(echo "$repos" | jq length)
+          jq -c '.modules.target_sw | to_entries[]' "$JSON_FILE" | while read -r module_entry; do
+            module_name=$(echo "$module_entry" | jq -r '.key')
+            repo_url=$(echo "$module_entry" | jq -r '.value.repo // empty')
+            version=$(echo "$module_entry" | jq -r '.value.version // empty')
+            branch=$(echo "$module_entry" | jq -r '.value.branch // empty')
+            hash=$(echo "$module_entry" | jq -r '.value.hash // empty')
 
-        # Initialize an empty string for paths to be outputted
-        repo_paths_output=""
+            echo "${module_name}_url=$repo_url" >> $GITHUB_OUTPUT
 
-        for i in $(seq 0 $((repo_count-1))); do
-          name=$(echo "$repos" | jq -r ".[$i].name")
-          url=$(echo "$repos" | jq -r ".[$i].url")
-          ref=$(echo "$repos" | jq -r ".[$i].version") # This can be a branch, tag, or commit hash
-          path=$(echo "$repos" | jq -r ".[$i].path") # e.g., "repos/score_baselibs"
+            if [ -n "$version" ]; then
+             echo "${module_name}_version=$version" >> $GITHUB_OUTPUT
+            fi
 
-          echo "Checking out $name ($ref) to $path"
+            if [ -n "$branch" ]; then
+              echo "${module_name}_branch=$branch" >> $GITHUB_OUTPUT
+            fi
 
-          # Create the parent directory if it doesn't exist
-          mkdir -p "$(dirname "$path")"
+            if [ -n "$hash" ]; then
+              echo "${module_name}_hash=$hash" >> $GITHUB_OUTPUT
+            fi
+          done
+      - name: Checkout all pinned repositories
+        id: checkout-repos
+        run: |
+          # jq is already installed by the previous step.
 
-          # Check if 'ref' looks like a commit hash (e.g., 40 hex characters)
-          # This is a heuristic; a more robust check might involve fetching refs first.
-          if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "  Detected commit hash. Cloning and then checking out."
-            git clone "$url" "$path"
-            (cd "$path" && git checkout "$ref")
-          else
-            echo "  Detected branch/tag. Cloning with --branch."
-            git clone --depth 1 --branch v"$ref" "$url" "$path"
-          fi
+          # Read repositories from the repos.json file created by the previous step
+          repos=$(cat repos.json)
+          repo_count=$(echo "$repos" | jq length)
 
-          # Append the path to the list, separated by commas
-          if [ -z "$repo_paths_output" ]; then
-            repo_paths_output="$path"
-          else
-            repo_paths_output="$repo_paths_output,$path"
-          fi
-        done
+          # Initialize an empty string for paths to be outputted
+          repo_paths_output=""
 
-        # Output all paths as a single variable
-        echo "repo_paths=$repo_paths_output" >> $GITHUB_OUTPUT
+          for i in $(seq 0 $((repo_count-1))); do
+            name=$(echo "$repos" | jq -r ".[$i].name")
+            url=$(echo "$repos" | jq -r ".[$i].url")
+            ref=$(echo "$repos" | jq -r ".[$i].version") # This can be a branch, tag, or commit hash
+            path=$(echo "$repos" | jq -r ".[$i].path") # e.g., "repos/score_baselibs"
 
-    - name: Initialize CodeQL for all repositories
-      uses: github/codeql-action/init@v4
-      with:
-        languages: cpp
-        build-mode: none
-        packs: codeql/misra-cpp-coding-standards
-        config-file: ./.github/codeql/codeql-config.yml
+            echo "Checking out $name ($ref) to $path"
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        upload-database: false # Don't upload databases for each repo
-        output: sarif-results/
-        category: "multi-repo-scan"
+            # Create the parent directory if it doesn't exist
+            mkdir -p "$(dirname "$path")"
 
-    - name: Recategorize Guidelines
-      if: always()
-      run: |
-        RECATEGORIZE_SCRIPT="codeql-coding-standards-repo/scripts/guideline_recategorization/recategorize.py"
-        CODING_STANDARDS_CONFIG="./.github/codeql/coding-standards.yml"
+            # Check if 'ref' looks like a commit hash (e.g., 40 hex characters)
+            # This is a heuristic; a more robust check might involve fetching refs first.
+            if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "  Detected commit hash. Cloning and then checking out."
+              git clone "$url" "$path"
+              (cd "$path" && git checkout "$ref")
+            else
+              echo "  Detected branch/tag. Cloning with --branch."
+              git clone --depth 1 --branch "$ref" "$url" "$path"
+            fi
 
-        CODING_STANDARDS_SCHEMA="codeql-coding-standards-repo/schemas/coding-standards-schema-1.0.0.json"
-        SARIF_SCHEMA="codeql-coding-standards-repo/schemas/sarif-schema-2.1.0.json"
+            # Append the path to the list, separated by commas
+            if [ -z "$repo_paths_output" ]; then
+              repo_paths_output="$path"
+            else
+              repo_paths_output="$repo_paths_output,$path"
+            fi
+          done
 
+          # Output all paths as a single variable
+          echo "repo_paths=$repo_paths_output" >> $GITHUB_OUTPUT
+      - name: Initialize CodeQL for all repositories
+        uses: github/codeql-action/init@v4
+        with:
+          languages: cpp
+          build-mode: none
+          packs: codeql/misra-cpp-coding-standards
+          config-file: ./.github/codeql/codeql-config.yml
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          upload-database: false # Don't upload databases for each repo
+          output: sarif-results/
+          category: "multi-repo-scan"
+      - name: Recategorize Guidelines
+        if: always()
+        run: |
+          RECATEGORIZE_SCRIPT="codeql-coding-standards-repo/scripts/guideline_recategorization/recategorize.py"
+          CODING_STANDARDS_CONFIG="./.github/codeql/coding-standards.yml"
 
-        SARIF_FILE="sarif-results/cpp.sarif"
-
-        mkdir -p sarif-results-recategorized
-        echo "Processing $SARIF_FILE for recategorization..."
-        python3 "$RECATEGORIZE_SCRIPT" \
-          --coding-standards-schema-file "$CODING_STANDARDS_SCHEMA" \
-          --sarif-schema-file "$SARIF_SCHEMA" \
-          "$CODING_STANDARDS_CONFIG" \
-          "$SARIF_FILE" \
-          "sarif-results-recategorized/$(basename "$SARIF_FILE")"
-
-          rm "$SARIF_FILE"
-          mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
-
-    - name: Generate HTML Report from SARIF
-      run: |
-        SARIF_FILE="sarif-results/cpp.sarif"
-        sarif html "$SARIF_FILE" --output codeql-report.html
-
-    - name: Upload SARIF results as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: codeql-sarif-results
-        path: sarif-results/
+          CODING_STANDARDS_SCHEMA="codeql-coding-standards-repo/schemas/coding-standards-schema-1.0.0.json"
+          SARIF_SCHEMA="codeql-coding-standards-repo/schemas/sarif-schema-2.1.0.json"
 
 
-    - name: Upload HTML Report as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: codeql-html-report
-        path: codeql-report.html
+          SARIF_FILE="sarif-results/cpp.sarif"
+
+          mkdir -p sarif-results-recategorized
+          echo "Processing $SARIF_FILE for recategorization..."
+          python3 "$RECATEGORIZE_SCRIPT" \
+            --coding-standards-schema-file "$CODING_STANDARDS_SCHEMA" \
+            --sarif-schema-file "$SARIF_SCHEMA" \
+            "$CODING_STANDARDS_CONFIG" \
+            "$SARIF_FILE" \
+            "sarif-results-recategorized/$(basename "$SARIF_FILE")"
+
+            rm "$SARIF_FILE"
+            mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
+      - name: Generate HTML Report from SARIF
+        run: |
+          SARIF_FILE="sarif-results/cpp.sarif"
+          sarif html "$SARIF_FILE" --output codeql-report.html
+      - name: Upload SARIF results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-results
+          path: sarif-results/
+      - name: Upload HTML Report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-html-report
+          path: codeql-report.html

--- a/.github/workflows/codeql-multiple-repo-scan.yml
+++ b/.github/workflows/codeql-multiple-repo-scan.yml
@@ -10,7 +10,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+
 name: "CodeQL - Multi-Repo Source Scan"
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -22,12 +24,10 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+
 permissions:
   contents: write
-# Do not flood CI with unneeded previous runs in PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/') }}
+
 jobs:
   analyze-repos:
     name: Analyze Multiple Repositories
@@ -37,56 +37,165 @@ jobs:
       packages: read
       actions: read
       contents: read
+
     steps:
-      - name: Checkout central repository
-        uses: actions/checkout@v4
-      - name: Checkout CodeQL Coding Standards scripts
-        uses: actions/checkout@v4
-        with:
-          repository: github/codeql-coding-standards
-          path: codeql-coding-standards-repo # Klonen in diesen Ordner
-          ref: main # Oder eine spezifische Release-Version, z.B. 'v2.53.0-dev'
-      # Add coding standard packages and dependencies
-      - name: Install Python dependencies for Coding Standards scripts
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install pyyaml jsonpath-ng jsonschema jsonpatch jsonpointer pytest sarif-tools
-      - name: Parse known_good.json and create repos.json
-        id: parse-repos
-        run: |
-          scripts/workflow/parse_repos.sh
-      - name: Checkout all pinned repositories
-        id: checkout-repos
-        run: |
-          scripts/workflow/checkout_repos.sh
-      - name: Initialize CodeQL for all repositories
-        uses: github/codeql-action/init@v4
-        with:
-          languages: cpp
-          build-mode: none
-          packs: codeql/misra-cpp-coding-standards
-          config-file: ./.github/codeql/codeql-config.yml
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
-        with:
-          upload-database: false # Don't upload databases for each repo
-          output: sarif-results/
-          category: "multi-repo-scan"
-      - name: Recategorize Guidelines
-        if: always()
-        run: |
-          scripts/workflow/recategorize_guidelines.sh
-      - name: Generate HTML Report from SARIF
-        run: |
-          SARIF_FILE="sarif-results/cpp.sarif"
-          sarif html "$SARIF_FILE" --output codeql-report.html
-      - name: Upload SARIF results as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: codeql-sarif-results
-          path: sarif-results/
-      - name: Upload HTML Report as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: codeql-html-report
-          path: codeql-report.html
+    - name: Checkout central repository
+      uses: actions/checkout@v4
+
+    - name: Checkout CodeQL Coding Standards scripts
+      uses: actions/checkout@v4
+      with:
+        repository: github/codeql-coding-standards
+        path: codeql-coding-standards-repo # Klonen in diesen Ordner
+        ref: main # Oder eine spezifische Release-Version, z.B. 'v2.53.0-dev'
+
+    # Add coding standard packages and dependencies
+    - name: Install Python dependencies for Coding Standards scripts
+      run: |
+        python3 -m pip install --upgrade pip
+        pip3 install pyyaml jsonpath-ng jsonschema jsonpatch jsonpointer pytest sarif-tools
+    - name: Parse known_good.json and create repos.json
+      id: parse-repos
+      run: |
+        sudo apt-get update && sudo apt-get install -y jq
+        JSON_FILE="./known_good.json"
+        # Check if the file exists
+        if [ ! -f "$JSON_FILE" ]; then
+          echo "Error file not found '$JSON_FILE' "
+          ls -la .
+          exit 1
+        fi
+        # Create repos.json from known_good.json
+        # This jq command transforms the 'modules' object into an array of repository objects
+        # with 'name', 'url', 'version' (branch/tag/hash), and 'path'.
+        jq '[.modules.target_sw | to_entries[] | {
+          name: .key,
+          url: .value.repo,
+          version: (.value.branch // .value.hash // .value.version),
+          path: ("repos/" + .key)
+        }]' "$JSON_FILE" > repos.json
+
+        echo "Generated repos.json:"
+        cat repos.json
+        echo "" # Add a newline for better readability
+        # The following GITHUB_OUTPUT variables are set for each module.
+        # These might be useful for other steps, but are not directly used by the 'checkout-repos' step
+        # which now reads 'repos.json' directly.
+        echo "MODULE_COUNT=$(jq '.modules.target_sw | length' "$JSON_FILE")" >> $GITHUB_OUTPUT
+        jq -c '.modules.target_sw | to_entries[]' "$JSON_FILE" | while read -r module_entry; do
+          module_name=$(echo "$module_entry" | jq -r '.key')
+          repo_url=$(echo "$module_entry" | jq -r '.value.repo // empty')
+          version=$(echo "$module_entry" | jq -r '.value.version // empty')
+          branch=$(echo "$module_entry" | jq -r '.value.branch // empty')
+          hash=$(echo "$module_entry" | jq -r '.value.hash // empty')
+          echo "${module_name}_url=$repo_url" >> $GITHUB_OUTPUT
+
+          if [ -n "$version" ]; then
+           echo "${module_name}_version=$version" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -n "$branch" ]; then
+            echo "${module_name}_branch=$branch" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -n "$hash" ]; then
+            echo "${module_name}_hash=$hash" >> $GITHUB_OUTPUT
+          fi
+        done
+
+    - name: Checkout all pinned repositories
+      id: checkout-repos
+      run: |
+        # jq is already installed by the previous step.
+
+        # Read repositories from the repos.json file created by the previous step
+        repos=$(cat repos.json)
+        repo_count=$(echo "$repos" | jq length)
+
+        # Initialize an empty string for paths to be outputted
+        repo_paths_output=""
+        for i in $(seq 0 $((repo_count-1))); do
+          name=$(echo "$repos" | jq -r ".[$i].name")
+          url=$(echo "$repos" | jq -r ".[$i].url")
+          ref=$(echo "$repos" | jq -r ".[$i].version") # This can be a branch, tag, or commit hash
+          path=$(echo "$repos" | jq -r ".[$i].path") # e.g., "repos/score_baselibs"
+
+          echo "Checking out $name ($ref) to $path"
+
+          # Create the parent directory if it doesn't exist
+          mkdir -p "$(dirname "$path")"
+          # Check if 'ref' looks like a commit hash (e.g., 40 hex characters)
+          # This is a heuristic; a more robust check might involve fetching refs first.
+          if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "  Detected commit hash. Cloning and then checking out."
+            git clone "$url" "$path"
+            (cd "$path" && git checkout "$ref")
+          else
+            echo "  Detected branch/tag. Cloning with --branch."
+            git clone --depth 1 --branch v"$ref" "$url" "$path"
+          fi
+
+          # Append the path to the list, separated by commas
+          if [ -z "$repo_paths_output" ]; then
+            repo_paths_output="$path"
+          else
+            repo_paths_output="$repo_paths_output,$path"
+          fi
+        done
+
+        # Output all paths as a single variable
+        echo "repo_paths=$repo_paths_output" >> $GITHUB_OUTPUT
+    - name: Initialize CodeQL for all repositories
+      uses: github/codeql-action/init@v4
+      with:
+        languages: cpp
+        build-mode: none
+        packs: codeql/misra-cpp-coding-standards
+        config-file: ./.github/codeql/codeql-config.yml
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        upload-database: false # Don't upload databases for each repo
+        output: sarif-results/
+        category: "multi-repo-scan"
+
+    - name: Recategorize Guidelines
+      if: always()
+      run: |
+        RECATEGORIZE_SCRIPT="codeql-coding-standards-repo/scripts/guideline_recategorization/recategorize.py"
+        CODING_STANDARDS_CONFIG="./.github/codeql/coding-standards.yml"
+
+        CODING_STANDARDS_SCHEMA="codeql-coding-standards-repo/schemas/coding-standards-schema-1.0.0.json"
+        SARIF_SCHEMA="codeql-coding-standards-repo/schemas/sarif-schema-2.1.0.json"
+
+
+        SARIF_FILE="sarif-results/cpp.sarif"
+
+        mkdir -p sarif-results-recategorized
+        echo "Processing $SARIF_FILE for recategorization..."
+        python3 "$RECATEGORIZE_SCRIPT" \
+          --coding-standards-schema-file "$CODING_STANDARDS_SCHEMA" \
+          --sarif-schema-file "$SARIF_SCHEMA" \
+          "$CODING_STANDARDS_CONFIG" \
+          "$SARIF_FILE" \
+          "sarif-results-recategorized/$(basename "$SARIF_FILE")"
+
+          rm "$SARIF_FILE"
+          mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
+    - name: Generate HTML Report from SARIF
+      run: |
+        SARIF_FILE="sarif-results/cpp.sarif"
+        sarif html "$SARIF_FILE" --output codeql-report.html
+    - name: Upload SARIF results as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: codeql-sarif-results
+        path: sarif-results/
+
+
+    - name: Upload HTML Report as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: codeql-html-report
+        path: codeql-report.html

--- a/.github/workflows/codeql-multiple-repo-scan.yml
+++ b/.github/workflows/codeql-multiple-repo-scan.yml
@@ -54,17 +54,20 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         pip3 install pyyaml jsonpath-ng jsonschema jsonpatch jsonpointer pytest sarif-tools
+
     - name: Parse known_good.json and create repos.json
       id: parse-repos
       run: |
         sudo apt-get update && sudo apt-get install -y jq
         JSON_FILE="./known_good.json"
+
         # Check if the file exists
         if [ ! -f "$JSON_FILE" ]; then
           echo "Error file not found '$JSON_FILE' "
           ls -la .
           exit 1
         fi
+
         # Create repos.json from known_good.json
         # This jq command transforms the 'modules' object into an array of repository objects
         # with 'name', 'url', 'version' (branch/tag/hash), and 'path'.
@@ -78,16 +81,19 @@ jobs:
         echo "Generated repos.json:"
         cat repos.json
         echo "" # Add a newline for better readability
+
         # The following GITHUB_OUTPUT variables are set for each module.
         # These might be useful for other steps, but are not directly used by the 'checkout-repos' step
         # which now reads 'repos.json' directly.
         echo "MODULE_COUNT=$(jq '.modules.target_sw | length' "$JSON_FILE")" >> $GITHUB_OUTPUT
+
         jq -c '.modules.target_sw | to_entries[]' "$JSON_FILE" | while read -r module_entry; do
           module_name=$(echo "$module_entry" | jq -r '.key')
           repo_url=$(echo "$module_entry" | jq -r '.value.repo // empty')
           version=$(echo "$module_entry" | jq -r '.value.version // empty')
           branch=$(echo "$module_entry" | jq -r '.value.branch // empty')
           hash=$(echo "$module_entry" | jq -r '.value.hash // empty')
+
           echo "${module_name}_url=$repo_url" >> $GITHUB_OUTPUT
 
           if [ -n "$version" ]; then
@@ -114,6 +120,7 @@ jobs:
 
         # Initialize an empty string for paths to be outputted
         repo_paths_output=""
+
         for i in $(seq 0 $((repo_count-1))); do
           name=$(echo "$repos" | jq -r ".[$i].name")
           url=$(echo "$repos" | jq -r ".[$i].url")
@@ -124,6 +131,7 @@ jobs:
 
           # Create the parent directory if it doesn't exist
           mkdir -p "$(dirname "$path")"
+
           # Check if 'ref' looks like a commit hash (e.g., 40 hex characters)
           # This is a heuristic; a more robust check might involve fetching refs first.
           if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -145,6 +153,7 @@ jobs:
 
         # Output all paths as a single variable
         echo "repo_paths=$repo_paths_output" >> $GITHUB_OUTPUT
+
     - name: Initialize CodeQL for all repositories
       uses: github/codeql-action/init@v4
       with:
@@ -183,10 +192,12 @@ jobs:
 
           rm "$SARIF_FILE"
           mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
+
     - name: Generate HTML Report from SARIF
       run: |
         SARIF_FILE="sarif-results/cpp.sarif"
         sarif html "$SARIF_FILE" --output codeql-report.html
+
     - name: Upload SARIF results as artifact
       uses: actions/upload-artifact@v4
       with:

--- a/scripts/workflow/recategorize_guidelines.sh
+++ b/scripts/workflow/recategorize_guidelines.sh
@@ -15,8 +15,9 @@ RECATEGORIZE_SCRIPT="codeql-coding-standards-repo/scripts/guideline_recategoriza
 CODING_STANDARDS_CONFIG="./.github/codeql/coding-standards.yml"
 CODING_STANDARDS_SCHEMA="codeql-coding-standards-repo/schemas/coding-standards-schema-1.0.0.json"
 SARIF_SCHEMA="codeql-coding-standards-repo/schemas/sarif-schema-2.1.0.json"
-SARIF_FILE="sarif-results/cpp.sarif" 
+SARIF_FILE="sarif-results/cpp.sarif"
 mkdir -p sarif-results-recategorized
+
 echo "Processing $SARIF_FILE for recategorization..."
 python3 "$RECATEGORIZE_SCRIPT" \
   --coding-standards-schema-file "$CODING_STANDARDS_SCHEMA" \
@@ -24,5 +25,27 @@ python3 "$RECATEGORIZE_SCRIPT" \
   "$CODING_STANDARDS_CONFIG" \
   "$SARIF_FILE" \
   "sarif-results-recategorized/$(basename "$SARIF_FILE")"
-  rm "$SARIF_FILE"
-  mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
+PY_EXIT=$?
+if [ $PY_EXIT -ne 0 ]; then
+  echo "Recategorization failed (exit code $PY_EXIT). SARIF file not updated." >&2
+  exit $PY_EXIT
+fi
+rm "$SARIF_FILE"
+mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
+
+# Ensure jq is available
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed. Please install jq and rerun this script." >&2
+  exit 1
+fi
+
+# Filter SARIF to only include results from repos/* (relative or absolute)
+echo "Filtering SARIF results to only include entries with paths matching (^|/)repos/ ..."
+jq '(.runs) |= map(.results |= map(select((.locations // [] | length > 0) and ((.locations[0].physicalLocation.artifactLocation.uri // "") | test("(^|/)repos/")))) )' "$SARIF_FILE" > "${SARIF_FILE}.filtered"
+if [ $? -eq 0 ]; then
+  mv "${SARIF_FILE}.filtered" "$SARIF_FILE"
+else
+  echo "jq filtering failed. SARIF file was not modified." >&2
+  rm -f "${SARIF_FILE}.filtered"
+  exit 1
+fi

--- a/scripts/workflow/recategorize_guidelines.sh
+++ b/scripts/workflow/recategorize_guidelines.sh
@@ -25,11 +25,11 @@ python3 "$RECATEGORIZE_SCRIPT" \
   "$CODING_STANDARDS_CONFIG" \
   "$SARIF_FILE" \
   "sarif-results-recategorized/$(basename "$SARIF_FILE")"
-PY_EXIT=$?
-if [ $PY_EXIT -ne 0 ]; then
-  echo "Recategorization failed (exit code $PY_EXIT). SARIF file not updated." >&2
-  exit $PY_EXIT
-fi
+# PY_EXIT=$?
+# if [ $PY_EXIT -ne 0 ]; then
+#   echo "Recategorization failed (exit code $PY_EXIT). SARIF file not updated." >&2
+#   exit $PY_EXIT
+# fi
 rm "$SARIF_FILE"
 mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
 

--- a/scripts/workflow/recategorize_guidelines.sh
+++ b/scripts/workflow/recategorize_guidelines.sh
@@ -33,19 +33,19 @@ fi
 rm "$SARIF_FILE"
 mv "sarif-results-recategorized/$(basename "$SARIF_FILE")" "$SARIF_FILE"
 
-# Ensure jq is available
-if ! command -v jq >/dev/null 2>&1; then
-  echo "Error: jq is required but not installed. Please install jq and rerun this script." >&2
-  exit 1
-fi
+# # Ensure jq is available
+# if ! command -v jq >/dev/null 2>&1; then
+#   echo "Error: jq is required but not installed. Please install jq and rerun this script." >&2
+#   exit 1
+# fi
 
-# Filter SARIF to only include results from repos/* (relative or absolute)
-echo "Filtering SARIF results to only include entries with paths matching (^|/)repos/ ..."
-jq '(.runs) |= map(.results |= map(select((.locations // [] | length > 0) and ((.locations[0].physicalLocation.artifactLocation.uri // "") | test("(^|/)repos/")))) )' "$SARIF_FILE" > "${SARIF_FILE}.filtered"
-if [ $? -eq 0 ]; then
-  mv "${SARIF_FILE}.filtered" "$SARIF_FILE"
-else
-  echo "jq filtering failed. SARIF file was not modified." >&2
-  rm -f "${SARIF_FILE}.filtered"
-  exit 1
-fi
+# # Filter SARIF to only include results from repos/* (relative or absolute)
+# echo "Filtering SARIF results to only include entries with paths matching (^|/)repos/ ..."
+# jq '(.runs) |= map(.results |= map(select((.locations // [] | length > 0) and ((.locations[0].physicalLocation.artifactLocation.uri // "") | test("(^|/)repos/")))) )' "$SARIF_FILE" > "${SARIF_FILE}.filtered"
+# if [ $? -eq 0 ]; then
+#   mv "${SARIF_FILE}.filtered" "$SARIF_FILE"
+# else
+#   echo "jq filtering failed. SARIF file was not modified." >&2
+#   rm -f "${SARIF_FILE}.filtered"
+#   exit 1
+# fi


### PR DESCRIPTION
This PR adds a post-processing filter step to the SARIF recategorization workflow so that only results associated with paths under repos/ are kept in the final SARIF output.

Changes:

Runs jq after recategorization to filter SARIF runs[].results[] by artifactLocation.uri.
Overwrites the original SARIF with the filtered output.