### PR TITLE
switch to pull_request trigger

### DIFF
--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
   id-token: write
 on:
-  pull_request_target: # Allows forks to trigger the docs build
+  pull_request: # Temporary allow only PRs from upstream until release v0.7
     types: [opened, reopened, synchronize]
   push:
     branches:


### PR DESCRIPTION
For v0.7 release there are needed modifications to the workflow (runner upgrade) which will fail on main currently.

Once thre release is finalized, updated modules and tools will be merged to main branch and pull_request_target restored to allow secrets usage in forks.

Until then please push directly to upstream if any critical PR is needed.