### PR TITLE
update codeql_config.yml to exclude advisory misra cpp rules

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -11,6 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 name: "Custom CodeQL Configuration for MISRA"
+
+query-filters:
+  - include:
+      tags:
+        - /external\/misra\/obligation\/(required|mandatory)/
+
 paths:
   - repos
 paths-ignore:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -11,12 +11,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 name: "Custom CodeQL Configuration for MISRA"
-
 query-filters:
   - include:
       tags:
         - /external\/misra\/obligation\/(required|mandatory)/
-
 paths:
   - repos
 paths-ignore:


### PR DESCRIPTION
update codeql_config.yml to exclude "advisory" rules from MISRA C++:2023

cuts violations by half (from 20k -> 10k)