### PR TITLE
Wrong target name for AutoSD in score_starter and wrong label in menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ bazel run //:docs_combo_experimental
 > Please refer to the README documents in the respective sub-directories for details about the specific integration.
 
 - [QNX](./images/qnx_x86_64//README.md)
-- [Red Hat AutoSD](./images/autosd_x86_64/build/README.md)
+- [Red Hat AutoSD](./images/autosd/)
 - [Elektrobit corbos Linux for Safety Applications](./images/ebclfsa_aarch64/README.md)
 - Linux x86_64
 

--- a/runners/docker_x86_64/scripts/BUILD
+++ b/runners/docker_x86_64/scripts/BUILD
@@ -17,7 +17,7 @@ sh_library(
     name = "run_docker",
     srcs = ["run_docker.sh"],
     visibility = [
-        "//images/auto_x86_64:__pkg__",
+        "//images/autosd:__pkg__",
         "//images/linux_x86_64:__pkg__",
     ],
     deps = ["@rules_shell//shell/runfiles"],

--- a/score_starter
+++ b/score_starter
@@ -25,7 +25,7 @@ mEntries = [
         "eb-aarch64",
     ),
     (
-        "Run Autosd x86_64 QEMU",
+        "Run AutoSD x86_64 Docker",
         "bazel --output_base=build/autosd-x86_64 run --config autosd-x86_64  //images/autosd:run",
         "autosd-x86_64",
     ),

--- a/score_starter
+++ b/score_starter
@@ -26,7 +26,7 @@ mEntries = [
     ),
     (
         "Run Autosd x86_64 QEMU",
-        "bazel --output_base=build/autosd-x86_64 run --config autosd-x86_64  //images/autosd_x86_64:run",
+        "bazel --output_base=build/autosd-x86_64 run --config autosd-x86_64  //images/autosd:run",
         "autosd-x86_64",
     ),
     ("Exit", "exit 0", "exit"),


### PR DESCRIPTION
'score_starter' refers to `//images/autosd_x86_x64`, but the target is actually called `autosd`.

The menu in `score_starter` wrongly states QEMU when actually a docker container is built.

