### PR TITLE
update cpp toolchains version

### DIFF
--- a/.github/workflows/build_and_test_autosd.yml
+++ b/.github/workflows/build_and_test_autosd.yml
@@ -66,7 +66,7 @@ jobs:
           sudo podman run -it --rm \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -v $PWD/images/autosd:/outputs \
-          quay.io/containers/skopeo:latest copy \
+          docker://quay.io/skopeo/stable:latest copy \
           docker-daemon:score_showcases_autosd:latest \
           oci-archive:/outputs/score_showcases_autosd_latest.oci
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -924,8 +924,8 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.16.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.18.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/2.1.1/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.1/MODULE.bazel": "c92d6f92b79fc96c4d9f033af21d65a0f8ce714da387da61160111e3b3babd25",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.1/source.json": "e3bb1beaf9e8e08fe682a616647d17badb1d7f8eeed4d2582277a9d7a1186c62",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.2/MODULE.bazel": "c9c02dfbd8548ef4226f20335711405e899aaf68250329bcb7b73a669b8e9cfe",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.2/source.json": "b8f84e57120b1887312c207ddbb2512cbb0e2b52252a7b3d0b3a72c4ac9df273",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_cr_checker/0.3.1/MODULE.bazel": "f49e037d7fbc0b2a8b2734fc6b47334e8cc8589ca7a5aa0f3ccca85cc5f79fac",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_cr_checker/0.3.1/source.json": "ad038d99c0e2a59cca3a7fa1aac6d87cd0d752314b65b52a91451ab0bd0f7171",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_dash_license_checker/0.1.2/MODULE.bazel": "89ba8c942dfd8d05cbf59b48868c919207aa189c670f97194078d5b8e09c6a8a",
@@ -8623,7 +8623,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "B1dX70i16FgdD9dV6dxjtnWG4LxzrZ2cRxQ4ptjUXbY=",
+        "bzlTransitiveDigest": "o7WlYvONzODJ0MAzhS1scFyAADDAbWm4WAvjzADhWiM=",
         "usagesDigest": "oxmc9zqxQOnppJnClchkYp6riYfqmi0+TBKIbpEW7SM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -8658,7 +8658,7 @@
                 "https://github.com/eclipse-score/inc_os_autosd/releases/download/continuous/autosd-toolchain-x86_64.tar.gz"
               ],
               "build_file": "@@score_bazel_cpp_toolchains+//packages/linux/x86_64/autosd/10.0:autosd.BUILD",
-              "sha256": "bb5324ec04895eb70b1fcb1787d25856b137962b0381d11f5b3406c37ee15984",
+              "sha256": "39091c500a31bc58d5934cc9c27f5fec4326f30d8bff88fe67737c86385bf39f",
               "strip_prefix": "sysroot"
             }
           },

--- a/bazel_common/score_gcc_toolchains.MODULE.bazel
+++ b/bazel_common/score_gcc_toolchains.MODULE.bazel
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.1")
+bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.2")
 
 gcc = use_extension("@score_bazel_cpp_toolchains//extensions:gcc.bzl", "gcc", dev_dependency = True)
 gcc.toolchain(


### PR DESCRIPTION
## Changes

* Bumps bazel_cpp_toolchains to 0.5.2 to include latest changes
* Uses stable skopeo container image in AutoSD CI