### PR TITLE
fix broken link to s-core book in release notes

### DIFF
--- a/docs/score_releases/release_note_score_v0_5_alpha.rst
+++ b/docs/score_releases/release_note_score_v0_5_alpha.rst
@@ -52,9 +52,10 @@ Highlights
 - Initial set of communication, persistency, orchestration, and base utility modules.
 - Experimental reference images for QNX, Red Hat AutoSD Linux, and EB corbos Linux for Safety Applications.
 
-Eclipse S-CORE book
--------------------
-The first version of the `Eclipse S-CORE book <https://eclipse-score.github.io/score/main/handbook/index.html>`_
+Eclipse S-CORE User’s Guide   
+---------------------------
+
+The `Eclipse S-CORE User’s Guide <https://eclipse-score.github.io/score/main/users_guide/index.html>`_
 is a “how-to” guide for users getting started with the project.
 It introduces the core concepts of Eclipse S-CORE and walks through building
 the ``scrample`` application step by step on top of the platform modules.

--- a/docs/score_releases/release_note_score_v0_5_beta.rst
+++ b/docs/score_releases/release_note_score_v0_5_beta.rst
@@ -49,9 +49,10 @@ Please be aware, that features may be incomplete, the software may exhibit insta
 Highlights
 -----------
 
-Eclipse S-CORE book
--------------------
-The `Eclipse S-CORE book <https://eclipse-score.github.io/score/main/handbook/index.html>`_
+Eclipse S-CORE User’s Guide   
+---------------------------
+
+The `Eclipse S-CORE User’s Guide <https://eclipse-score.github.io/score/main/users_guide/index.html>`_
 is a “how-to” guide for users getting started with the project or who want to contribute new modules.
 It introduces the core concepts of Eclipse S-CORE and walks through building
 the ``scrample`` application step by step on top of the platform modules.

--- a/docs/score_releases/release_note_score_v0_6.rst
+++ b/docs/score_releases/release_note_score_v0_6.rst
@@ -47,9 +47,10 @@ Please be aware, that features may be incomplete, the software may exhibit insta
 Highlights
 -----------
 
-Eclipse S-CORE book
--------------------
-The `Eclipse S-CORE book <https://eclipse-score.github.io/score/main/handbook/index.html>`_
+Eclipse S-CORE User’s Guide   
+---------------------------
+
+The `Eclipse S-CORE User’s Guide <https://eclipse-score.github.io/score/main/users_guide/index.html>`_
 is a “how-to” guide for users getting started with the project or who want to contribute new modules.
 
 

--- a/docs/score_releases/release_note_score_v0_7.rst
+++ b/docs/score_releases/release_note_score_v0_7.rst
@@ -61,10 +61,10 @@ On the documentation side, the build pipeline was fixed and an integration statu
 Infrastructure-wise, Bzlmod lockfile consistency is now enforced in CI, the AutoSD image version is frozen for reproducible builds, and image filesystem rules were migrated to the new Bazel API.
 
 
-Eclipse S-CORE book
--------------------
+Eclipse S-CORE User’s Guide   
+---------------------------
 
-The `Eclipse S-CORE book <https://eclipse-score.github.io/score/main/handbook/index.html>`_
+The `Eclipse S-CORE User’s Guide <https://eclipse-score.github.io/score/main/users_guide/index.html>`_
 is a “how-to” guide for users getting started with the project or who want to contribute new modules.
 
 S-CORE Platform scope


### PR DESCRIPTION
Replace link to s-core book with link to s-core handbook and update description. Currently the link in https://eclipse-score.github.io/reference_integration/main/score_releases/release_note_score_07.html#eclipse-s-core-book is broken.