### PR TITLE
Fix four obvious bugs from PR #230 review

### DIFF
--- a/.github/skills/overall-status/SKILL.md
+++ b/.github/skills/overall-status/SKILL.md
@@ -807,13 +807,13 @@ def comp_req_cell(contents, *, trlc=False):
     for c in contents:
         v, t = count_directives_with_status(c, ('comp_req',)); cv+=v; ct+=t
         v, t = count_directives_with_status(c, ('aou_req',));  av+=v; at+=t
+    if ct == 0 and at == 0: return "❌ Open"
     parts = []
     if ct or trlc: parts.append(f"{cv}/{ct} comp_req" + (" [TRLC]" if trlc else ""))
     if at:         parts.append(f"{av}/{at} AoU")
-    if not parts:  return "❌ Open"
     body = " + ".join(parts)
     tot_v, tot_t = cv + av, ct + at
-    if tot_t == 0 or tot_v == tot_t: return f"✅ Available ({body})"
+    if tot_v == tot_t: return f"✅ Available ({body})"
     return f"🔄 {tot_v*100//tot_t}% ({body})"
 ```
 
@@ -885,7 +885,7 @@ Stop and investigate if:
 ### Step 6 — Write the RST
 
 Update each PA's module table and the **Rollout status** `raw:: html`
-block above it (see §5.4). Source links as in §5.2. Pie-chart row and the
+block above it (see §5.5). Source links as in §5.2. Pie-chart row and the
 `Process Status` rubric stay unchanged unless the sphinx-needs tag
 changes.
 
@@ -1040,8 +1040,8 @@ contribute 0.
 > Rationale: the charts visualise *scope growth* across releases, not
 > validation maturity. Drafts and invalids count.
 >
-> Practical consequence: use `count_directives(...)` (returns total only),
-> **never** `count_directives_with_status(...)` for chart numbers. This is
+> Practical consequence: use `count_directives_with_status(...)[1]` (returns total only),
+> **never** the full return value of `count_directives_with_status(...)` for chart numbers. This is
 > particularly important for Lifecycle, whose feature-level requirements
 > were largely `:status: draft` or `:status: invalid` in v0.5/v0.6 — a
 > valid-only counter would report 0 instead of ~92.

--- a/scripts/quality_runners.py
+++ b/scripts/quality_runners.py
@@ -340,8 +340,8 @@ def main() -> bool:
 
     # Check all exit codes and return non-zero if any test or coverage extraction failed
     return any(
-        result_ut["exit_code"] != 0 or result_cov["exit_code"] != 0
-        for result_ut, result_cov in zip(unit_tests_summary.values(), coverage_summary.values())
+        r["exit_code"] != 0
+        for r in {**unit_tests_summary, **coverage_summary}.values()
     )
 
 

--- a/scripts/quality_runners.py
+++ b/scripts/quality_runners.py
@@ -339,10 +339,7 @@ def main() -> bool:
     pprint(coverage_summary, width=120)
 
     # Check all exit codes and return non-zero if any test or coverage extraction failed
-    return any(
-        r["exit_code"] != 0
-        for r in {**unit_tests_summary, **coverage_summary}.values()
-    )
+    return any(r["exit_code"] != 0 for r in {**unit_tests_summary, **coverage_summary}.values())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Four unambiguous bugs were found during review of #230 that each have a single correct fix with no design ambiguity.

## What

**`comp_req_cell()` TRLC zero bug** — when called with `trlc=True` and no directives found (`ct==0, at==0`), the function returned `✅ Available (0/0 comp_req [TRLC])` instead of `❌ Open`. The `trlc` flag forced a non-empty `parts` list, bypassing the `if not parts` guard. Fix: check `ct == 0 and at == 0` unconditionally before building `parts`.

**Stale §5.4 cross-reference** — the heading renumber (Rollout status: §5.4 → §5.5) was applied to the heading but not to the in-text `(see §5.4)` in Step 6, pointing implementers at the Pie chart row instead.

**`count_directives()` called but never defined** — §6a.2 told Claude to call `count_directives(...)` (total only), but only `count_directives_with_status(...)` exists. Replaced with `count_directives_with_status(...)[1]`.

**`zip()` drops rust coverage exit codes** — `unit_tests_summary` has one entry per module, `coverage_summary` has up to two (`_cpp`, `_rust`). `zip()` truncates to the shorter dict, silently ignoring rust coverage failures beyond the first module. Replaced with a flat check over the merged dict.

## Changes

- `.github/skills/overall-status/SKILL.md` — fix `comp_req_cell()` zero guard, update §5.4→§5.5 cross-ref, fix `count_directives` reference
- `scripts/quality_runners.py` — replace `zip()`-based exit-code check with a flat check over both summary dicts