### PR TITLE
fix: mount Docker socket in devcontainer to fix bazel run (#248)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "eclipse-s-core",
     "image": "ghcr.io/eclipse-score/devcontainer:v1.3.0",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    ],
     "postCreateCommand": "bash .devcontainer/prepare_workspace.sh",
     "postStartCommand": "ssh-keygen -f '/home/vscode/.ssh/known_hosts' -R '[localhost]:2222' || true"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
-    "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:v1.3.0",
-    "mounts": [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-    ],
-    "postCreateCommand": "bash .devcontainer/prepare_workspace.sh",
-    "postStartCommand": "ssh-keygen -f '/home/vscode/.ssh/known_hosts' -R '[localhost]:2222' || true"
+  "name": "eclipse-s-core",
+  "image": "ghcr.io/eclipse-score/devcontainer:v1.3.0",
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
+  "postCreateCommand": "bash .devcontainer/prepare_workspace.sh",
+  "postStartCommand": "ssh-keygen -f '/home/vscode/.ssh/known_hosts' -R '[localhost]:2222' || true"
 }


### PR DESCRIPTION
**Problem**
Running bazel run //images/linux_x86_64:run inside the devcontainer fails after a successful build with:

`failed to connect to the docker API at unix:///var/run/docker.sock;
dial unix /var/run/docker.sock: connect: no such file or directory`

**Root Cause**
The runners/docker_x86_64/scripts/run_docker.sh script (invoked by the :run target) calls docker load and docker run to load and start the OCI image. The devcontainer was running without access to the host Docker daemon because .devcontainer/devcontainer.json did not mount the Docker socket.

**Fix**
Added a mounts entry in .devcontainer/devcontainer.json to bind-mount the host socket at /var/run/docker.sock into the container. This allows Docker CLI commands inside the devcontainer to communicate with the host Docker daemon (Docker-outside-of-Docker pattern).

**Testing**

- Open the repo in the devcontainer
- Run bazel --output_base=build/linux-x86_64 run --config linux-x86_64 //images/linux_x86_64:run
- Build and execution both complete without the socket error

Fixes #248> failed to connect to the docker API at unix:///var/run/docker.sock;
dial unix /var/run/docker.sock: connect: no such file or directory

