### PR TITLE
Enable cr_checker copyright check via pre-commit hook

### DIFF
--- a/.devcontainer/prepare_workspace.sh
+++ b/.devcontainer/prepare_workspace.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 set -euo pipefail
 
 # Install pipx

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,35 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Copyright check
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+jobs:
+  copyright-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # Runs the `copyright` hook from .pre-commit-config.yaml (cr_checker from
+      # eclipse-score/tooling). The hook reports any file missing a copyright
+      # header and fails the job, gating PRs without touching Bazel.
+      - name: Run cr_checker via pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: copyright --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+# Runs cr_checker (copyright header check) directly from the eclipse-score/tooling
+# repo as a pre-commit hook, instead of via the Bazel `//:copyright` target.
+#
+# Rationale (see https://github.com/eclipse-score/reference_integration/issues/166):
+# the Bazel target pulls in the docs() -> needs_json -> @score_process graph, which
+# fails to resolve because score_process/score_platform are dev_dependencies in the
+# score modules and are therefore invisible when reference_integration aggregates
+# them. The pre-commit hook runs the checker as a standalone script over the repo's
+# files, so it is unaffected by Bazel module resolution.
+repos:
+  - repo: https://github.com/eclipse-score/tooling
+    rev: 31ff8eee214e4e97ef8f5cb46e443273515b63ec
+    hooks:
+      - id: copyright

--- a/.vscode/rustfmt.sh
+++ b/.vscode/rustfmt.sh
@@ -1,3 +1,15 @@
 #!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 
 bazel run @score_tooling//format_checker:rustfmt_with_policies

--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@
 # *******************************************************************************
 
 load("@score_docs_as_code//:docs.bzl", "docs")
-load("@score_tooling//:defs.bzl", "copyright_checker", "setup_starpls", "use_format_targets")
+load("@score_tooling//:defs.bzl", "setup_starpls", "use_format_targets")
 
 # Docs-as-code
 docs(
@@ -38,35 +38,6 @@ docs(
 # Bazel formatting
 setup_starpls(
     name = "starpls_server",
-    visibility = ["//visibility:public"],
-)
-
-# Copyright check
-#
-# NOTE: CI enforces copyright headers via the pre-commit `copyright` hook
-# (see //.pre-commit-config.yaml and .github/workflows/copyright.yml), not this
-# Bazel target. `bazel run //:copyright.check` currently fails to analyze because
-# its "docs" src pulls in the docs() -> needs_json graph, which references
-# @score_process/@score_platform; those are dev_dependencies in the score modules
-# and so are not visible when reference_integration aggregates them.
-# Tracked in https://github.com/eclipse-score/reference_integration/issues/166.
-copyright_checker(
-    name = "copyright",
-    srcs = [
-        ".github",
-        "bazel_common",
-        "docs",
-        "feature_integration_tests",
-        "images",
-        "runners",
-        "rust_coverage",
-        "scripts",
-        "showcases",
-        "//:BUILD",
-        "//:MODULE.bazel",
-    ],
-    config = "@score_tooling//cr_checker/resources:config",
-    template = "@score_tooling//cr_checker/resources:templates",
     visibility = ["//visibility:public"],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -42,6 +42,14 @@ setup_starpls(
 )
 
 # Copyright check
+#
+# NOTE: CI enforces copyright headers via the pre-commit `copyright` hook
+# (see //.pre-commit-config.yaml and .github/workflows/copyright.yml), not this
+# Bazel target. `bazel run //:copyright.check` currently fails to analyze because
+# its "docs" src pulls in the docs() -> needs_json graph, which references
+# @score_process/@score_platform; those are dev_dependencies in the score modules
+# and so are not visible when reference_integration aggregates them.
+# Tracked in https://github.com/eclipse-score/reference_integration/issues/166.
 copyright_checker(
     name = "copyright",
     srcs = [

--- a/bazel_common/score_images.MODULE.bazel
+++ b/bazel_common/score_images.MODULE.bazel
@@ -1,3 +1,15 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 bazel_dep(name = "rules_oci", version = "2.3.1")
 git_override(
     module_name = "rules_oci",

--- a/docs/s_core_v_1/roadmap/overall_status.rst
+++ b/docs/s_core_v_1/roadmap/overall_status.rst
@@ -1,3 +1,16 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
 :hide-toc:
 
 Overall Status

--- a/docs/s_core_v_1/roadmap/overall_status.rst
+++ b/docs/s_core_v_1/roadmap/overall_status.rst
@@ -11,6 +11,7 @@
    #
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
+
 :hide-toc:
 
 Overall Status

--- a/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_build_helpers.h
+++ b/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_build_helpers.h
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #ifndef INTERNALS_PERSISTENCY_KVS_BUILD_HELPERS_H_
 #define INTERNALS_PERSISTENCY_KVS_BUILD_HELPERS_H_

--- a/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_instance.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_instance.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "kvs_instance.h"
 

--- a/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_instance.h
+++ b/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_instance.h
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #ifndef INTERNALS_PERSISTENCY_KVS_INSTANCE_H_
 #define INTERNALS_PERSISTENCY_KVS_INSTANCE_H_

--- a/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_parameters.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_parameters.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "kvs_parameters.h"
 

--- a/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_parameters.h
+++ b/feature_integration_tests/test_scenarios/cpp/src/internals/persistency/kvs_parameters.h
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #ifndef INTERNALS_PERSISTENCY_KVS_PARAMETERS_H_
 #define INTERNALS_PERSISTENCY_KVS_PARAMETERS_H_

--- a/feature_integration_tests/test_scenarios/cpp/src/main.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/main.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include <iostream>
 #include <vector>

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/mod.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/mod.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include <scenario.hpp>
 

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/default_values.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/default_values.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_build_helpers.h"
 #include "../../internals/persistency/kvs_instance.h"

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/default_values_ignored.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/default_values_ignored.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_instance.h"
 

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/multi_instance_isolation.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/multi_instance_isolation.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_build_helpers.h"
 #include "../../internals/persistency/kvs_instance.h"

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/multiple_kvs_per_app.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/multiple_kvs_per_app.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_instance.h"
 

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/reset_to_default.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/reset_to_default.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_build_helpers.h"
 #include "../../internals/persistency/kvs_instance.h"

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/supported_datatypes.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/supported_datatypes.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_build_helpers.h"
 #include "../../internals/persistency/kvs_instance.h"

--- a/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/utf8_defaults.cpp
+++ b/feature_integration_tests/test_scenarios/cpp/src/scenarios/persistency/utf8_defaults.cpp
@@ -1,15 +1,15 @@
-// *******************************************************************************
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// See the NOTICE file(s) distributed with this work for additional
-// information regarding copyright ownership.
-//
-// This program and the accompanying materials are made available under the
-// terms of the Apache License Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0
-//
-// SPDX-License-Identifier: Apache-2.0
-// *******************************************************************************
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 #include "../../internals/persistency/kvs_build_helpers.h"
 #include "../../internals/persistency/kvs_instance.h"

--- a/images/ebclfsa_aarch64/build/config-overlay/BUILD
+++ b/images/ebclfsa_aarch64/build/config-overlay/BUILD
@@ -1,3 +1,15 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 exports_files(
     [
         "usr/bin/delayed-start.sh",

--- a/images/ebclfsa_aarch64/build/config-overlay/usr/bin/delayed-start.sh
+++ b/images/ebclfsa_aarch64/build/config-overlay/usr/bin/delayed-start.sh
@@ -1,3 +1,15 @@
 #!/bin/sh
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 sleep 2
 /showcases/bin/cli

--- a/runners/qemu_aarch64/scripts/BUILD
+++ b/runners/qemu_aarch64/scripts/BUILD
@@ -1,1 +1,13 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 exports_files(["run_qemu.sh"])


### PR DESCRIPTION
Closes #166

## Summary

- Enables copyright header enforcement in CI via the `copyright` pre-commit hook from `eclipse-score/tooling`, bypassing the broken Bazel `//:copyright` target.
- Fixes copyright headers across 20 source files that were either missing a header or using the wrong comment style for their file type.

## Changes

### Enabler

| File | Change |
|---|---|
| `.pre-commit-config.yaml` | New — `copyright` hook from `eclipse-score/tooling` rev `31ff8eee` |
| `.github/workflows/copyright.yml` | New — CI job running `pre-commit run copyright --all-files` on every PR and merge group |

## Verification

```sh
# Copyright hook — all files pass
pre-commit run copyright --all-files
# → Passed