### PR TITLE
Bump `score_bazel_cpp_toolchains` to the latest version

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -924,8 +924,8 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.16.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/1.18.0/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_swift/2.1.1/MODULE.bazel": "not found",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.2/MODULE.bazel": "c9c02dfbd8548ef4226f20335711405e899aaf68250329bcb7b73a669b8e9cfe",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.2/source.json": "b8f84e57120b1887312c207ddbb2512cbb0e2b52252a7b3d0b3a72c4ac9df273",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.4/MODULE.bazel": "5f14457f9b708302db05b5dc3c07bd41ae19b91cabf98a0dbffdca622bd6ac91",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_bazel_cpp_toolchains/0.5.4/source.json": "2946be24c6b978aa788c934643aa7ec68aac4a926bea4eaa81d512fd48e9f4a8",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_cr_checker/0.3.1/MODULE.bazel": "f49e037d7fbc0b2a8b2734fc6b47334e8cc8589ca7a5aa0f3ccca85cc5f79fac",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_cr_checker/0.3.1/source.json": "ad038d99c0e2a59cca3a7fa1aac6d87cd0d752314b65b52a91451ab0bd0f7171",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_dash_license_checker/0.1.2/MODULE.bazel": "89ba8c942dfd8d05cbf59b48868c919207aa189c670f97194078d5b8e09c6a8a",
@@ -8623,7 +8623,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "o7WlYvONzODJ0MAzhS1scFyAADDAbWm4WAvjzADhWiM=",
+        "bzlTransitiveDigest": "2cUGR4ZuwjW20KVJPJLXvx73CXLQCefFAx0w0kwTfxo=",
         "usagesDigest": "oxmc9zqxQOnppJnClchkYp6riYfqmi0+TBKIbpEW7SM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel_common/score_gcc_toolchains.MODULE.bazel
+++ b/bazel_common/score_gcc_toolchains.MODULE.bazel
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.2")
+bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.4")
 
 gcc = use_extension("@score_bazel_cpp_toolchains//extensions:gcc.bzl", "gcc", dev_dependency = True)
 gcc.toolchain(


### PR DESCRIPTION
The latest version of toolchain provides support for coverage for QNX builds.