### PR TITLE
add logging demoapp

### DIFF
--- a/bazel_common/score_modules_target_sw.MODULE.bazel
+++ b/bazel_common/score_modules_target_sw.MODULE.bazel
@@ -71,11 +71,12 @@ git_override(
 bazel_dep(name = "score_logging")
 git_override(
     module_name = "score_logging",
-    commit = "6282f3a2ec6b1eeeab87c8e9a4435c586bcf9973",
+    commit = "a6da5cfca65c1a2402f94ef65a61aa7737d1aa32",
     patch_strip = 1,
     patches = [
         "//patches/logging:002-needs-json-deps-not-dev-dependency.patch",
         "//patches/logging:003-docs-as-code-not-dev-dependency.patch",
+        "//patches/logging:004-rules-pkg-not-dev-dependency.patch",
     ],
     remote = "https://github.com/eclipse-score/logging.git",
 )

--- a/feature_integration_tests/itf/test_remote_logging.py
+++ b/feature_integration_tests/itf/test_remote_logging.py
@@ -12,7 +12,6 @@
 # *******************************************************************************
 
 import logging
-import os
 import time
 
 import pytest
@@ -44,6 +43,12 @@ _LINUX_DATAROUTER_START_CMD = "cd /usr/bin/datarouter && nohup ./datarouter --no
 # network interface required for DLT messages to reach the host via the Docker bridge.
 _LINUX_CHECK_MULTICAST_ROUTE_CMD = "ip route add 224.0.0.0/4 dev eth0 2>/dev/null || true"
 _DATAROUTER_STARTUP_TIMEOUT_SEC = 2
+
+# DLT message identifiers for the Logging App
+LOGGING_APP_ID = "EXA"
+LOGGING_CTX_ID = "DFLT"
+
+_LOGGINGAPP_START_CMD = "cd /showcases/data/logging/logging_app/etc && nohup /showcases/bin/logging_app &"
 
 
 def _is_qnx(target):
@@ -110,4 +115,40 @@ def test_remote_logging(datarouter_running, dlt_config):
 
     assert message_count > 1, (
         f"Expected atleast one DLT message with app_id: {APP_ID} and context_id: {CTX_ID}, but got {message_count}"
+    )
+
+
+def test_logging_app_logs_forwarded_to_dlt(datarouter_running, target, dlt_config):
+    """Verifies that Logging App logs are forwarded to DLT."""
+
+    with DltWindow(
+        protocol=Protocol.UDP,
+        host_ip=dlt_config.host_ip,
+        multicast_ips=dlt_config.multicast_ips,
+        print_to_stdout=True,
+        binary_path=dlt_config.dlt_receive_path,
+    ) as window:
+        logger.info("Starting logging_app...")
+        exit_code, out = target.execute(_LOGGINGAPP_START_CMD)
+
+        logger.info("logging_app start exit_code=%s", exit_code)
+        logger.info(out.decode(errors="replace"))
+
+        assert exit_code == 0, "Failed to start logging_app"
+
+        time.sleep(CAPTURE_DURATION_SECONDS)
+
+    record = window.record(filters=[(LOGGING_APP_ID, LOGGING_CTX_ID)])
+    messages = record.find(query=dict(apid=LOGGING_APP_ID, ctid=LOGGING_CTX_ID))
+
+    logger.debug(
+        "Found %d messages with app_id=%s, context_id=%s",
+        len(messages),
+        LOGGING_APP_ID,
+        LOGGING_CTX_ID,
+    )
+
+    assert len(messages) > 0, (
+        f"Expected at least one DLT message with app_id={LOGGING_APP_ID} "
+        f"and context_id={LOGGING_CTX_ID}, but got {len(messages)}"
     )

--- a/known_good.json
+++ b/known_good.json
@@ -97,10 +97,11 @@
             },
             "score_logging": {
                 "repo": "https://github.com/eclipse-score/logging.git",
-                "hash": "6282f3a2ec6b1eeeab87c8e9a4435c586bcf9973",
+                "hash": "a6da5cfca65c1a2402f94ef65a61aa7737d1aa32",
                 "bazel_patches": [
                     "//patches/logging:002-needs-json-deps-not-dev-dependency.patch",
-                    "//patches/logging:003-docs-as-code-not-dev-dependency.patch"
+                    "//patches/logging:003-docs-as-code-not-dev-dependency.patch",
+                    "//patches/logging:004-rules-pkg-not-dev-dependency.patch"
 
                 ],
                 "metadata": {

--- a/patches/logging/004-rules-pkg-not-dev-dependency.patch
+++ b/patches/logging/004-rules-pkg-not-dev-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 5eed2f9..06fb222 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -47,7 +47,7 @@ bazel_dep(name = "score_itf", version = "0.4.0", dev_dependency = True)
+ 
+ # OCI / Docker image rules for integration tests
+ bazel_dep(name = "rules_oci", version = "2.2.7", dev_dependency = True)
+-bazel_dep(name = "rules_pkg", version = "1.2.0", dev_dependency = True)
++bazel_dep(name = "rules_pkg", version = "1.2.0")
+ 
+ # QNX image filesystem rules for QNX integration tests
+ bazel_dep(name = "score_rules_imagefs", version = "0.0.1", dev_dependency = True)

--- a/showcases/BUILD
+++ b/showcases/BUILD
@@ -19,6 +19,7 @@ score_pkg_bundle(
         "//showcases/standalone:comm_pkg_files",
         "//showcases/standalone:kyron_pkg_files",
         "//showcases/standalone:time_pkg_files",
+        "//showcases/standalone:logging_pkg_files",
         "//showcases/orchestration_persistency:orch_per_pkg_files",
         "//showcases/simple_lifecycle:simple_lifecycle_pkg_files",
     ],

--- a/showcases/README.md
+++ b/showcases/README.md
@@ -1,0 +1,7 @@
+# Logging App Demo
+ 
+This Logging App demonstrates logging using mw::log with all log levels and configured backends (kConsole|kRemote|kFile) enabled.
+
+For remote (DLT) logging, please refer to the following documentation:
+ 
+[Remote logging](https://github.com/eclipse-score/logging/blob/main/score/datarouter/doc/guideline/dlt_capture_demo.md)

--- a/showcases/standalone/BUILD
+++ b/showcases/standalone/BUILD
@@ -50,3 +50,19 @@ score_pkg_bundle(
     ],
     package_dir = "standalone",
 )
+
+score_pkg_bundle(
+    name = "logging",
+    bins = [
+        "@score_logging//score/test/component/logging_app:logging_app",
+        "@score_logging//score/test/component/dlt_generator_app:dlt_generator",
+    ],
+    config_data = [
+        "//showcases/standalone:logging.score.json",
+    ],
+    custom_layout = {
+        "//showcases/standalone/configs:logging_app.json": "logging_app/etc/logging.json",
+        "//showcases/standalone/configs:dlt_generator.json": "dlt_generator/etc/logging.json",
+    },
+    package_dir = "standalone",
+)

--- a/showcases/standalone/configs/BUILD
+++ b/showcases/standalone/configs/BUILD
@@ -1,0 +1,17 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+exports_files([
+    "logging_app.json",
+    "dlt_generator.json",
+])

--- a/showcases/standalone/configs/dlt_generator.json
+++ b/showcases/standalone/configs/dlt_generator.json
@@ -1,0 +1,7 @@
+{
+  "appId": "LGGG",
+  "appDesc": "DLT Generator App",
+  "logMode": "kConsole|kRemote",
+  "logLevel": "kVerbose",
+  "logLevelThresholdConsole": "kDebug"
+}

--- a/showcases/standalone/configs/logging_app.json
+++ b/showcases/standalone/configs/logging_app.json
@@ -1,0 +1,7 @@
+{
+  "appId": "EXA",
+  "appDesc": "Example App",
+  "logMode": "kConsole|kRemote",
+  "logLevel": "kVerbose",
+  "logLevelThresholdConsole": "kVerbose"
+}

--- a/showcases/standalone/logging.score.json
+++ b/showcases/standalone/logging.score.json
@@ -1,0 +1,27 @@
+{
+    "name": "LoggingApp Demo",
+    "description": "A Logging app that demonstrates logging with mw::log with kConsole|kRemote|kFile config.",
+    "apps": [
+      {
+        "path": "/bin/sh",
+        "args": [
+          "-c",
+          "cd /usr/bin/datarouter && ./datarouter --no_adaptive_runtime >/dev/null 2>&1 &"
+        ],
+        "env": {}
+      },
+      {
+        "path": "/showcases/bin/logging_app",
+        "args": [],
+        "env": {},
+        "dir": "/showcases/data/logging/logging_app/etc"
+      },
+
+      {
+        "path": "/showcases/bin/dlt_generator",
+        "args": [],
+        "env": {},
+        "dir": "/showcases/data/logging/dlt_generator/etc"
+      }
+    ]
+  }


### PR DESCRIPTION
Summary

This PR adds a Logging example showcase demonstrating local and remote logging.

The example generates logs for all supported severity levels.

Related

Issue: https://github.com/eclipse-score/reference_integration/issues/229

Verification
DEBUG, INFO, WARN, ERROR and FATAL logs generated
Logs visible in console output
Logs visible in DLT Viewer and Chipmunk