### PR TITLE
chore(known_good): bump score_itf to v0.5.0

### DIFF
--- a/bazel_common/score_modules_tooling.MODULE.bazel
+++ b/bazel_common/score_modules_tooling.MODULE.bazel
@@ -24,7 +24,7 @@ git_override(
 bazel_dep(name = "score_itf")
 git_override(
     module_name = "score_itf",
-    commit = "bf5294d7618e361c224edbd754060cee810285eb",
+    commit = "802e0186d373e0d9d67c1c9ccb1ea08952c7ad06",
     remote = "https://github.com/eclipse-score/itf.git",
 )
 

--- a/known_good.json
+++ b/known_good.json
@@ -135,7 +135,7 @@
             },
             "score_itf": {
                 "repo": "https://github.com/eclipse-score/itf.git",
-                "hash": "bf5294d7618e361c224edbd754060cee810285eb"
+                "hash": "802e0186d373e0d9d67c1c9ccb1ea08952c7ad06"
             },
             "score_tooling": {
                 "repo": "https://github.com/eclipse-score/tooling.git",


### PR DESCRIPTION
## Summary
- update `score_itf` in `known_good.json` to the latest upstream ITF release `v0.5.0`
- move hash from `bf5294d7618e361c224edbd754060cee810285eb` to `802e0186d373e0d9d67c1c9ccb1ea08952c7ad06`

## Validation
- ran `python3 scripts/known_good/known_good_to_workspace_metadata.py`
- verified only `known_good.json` changed